### PR TITLE
Compatibility updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+segments/
+output/

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -14,10 +14,12 @@
     "# assert torch.cuda.is_available(), 'You need a GPU! In Colab, go to Runtime -> Change runtime type -> Hardware accelerator -> GPU'\n",
     "\n",
     "# !pip install segments-ai\n",
-    "# !pip install pyyaml==5.1\n",
-    "# !pip install torch==1.8.1\n",
-    "# !pip install torchvision==0.9.1\n",
-    "# !pip install detectron2 -f https://dl.fbaipublicfiles.com/detectron2/wheels/cu101/torch1.8/index.html\n",
+    "# !pip install pyyaml\n",
+    "# !pip install torch\n",
+    "# !pip install torchvision\n",
+    "# !pip install scikit-image\n",
+    "# !pip install setuptools wheel\n",
+    "# !pip install 'git+https://github.com/facebookresearch/detectron2.git\n",
     "# !git clone https://github.com/segments-ai/fast-labeling-workflow\n",
     "# %cd fast-labeling-workflow"
    ]
@@ -87,7 +89,8 @@
     "\n",
     "# Set up the client\n",
     "client = SegmentsClient('YOUR_API_KEY')\n",
-    "dataset_name = 'bert/tomatoes' # Name of a dataset you've created on Segments.ai\n",
+    "segments_dataset = client.add_dataset(\"tomatoes\")\n",
+    "dataset_name = segments_dataset.full_name\n",
     "\n",
     "# Get a list of image URLs\n",
     "image_urls = get_image_urls('tomatoes')\n",
@@ -198,7 +201,7 @@
     "    attributes = {\n",
     "        'format_version': '0.1',\n",
     "        'annotations': annotations,\n",
-    "        'segmentation_bitmap': { 'url': asset['url'] },\n",
+    "        'segmentation_bitmap': { 'url': asset.url },\n",
     "    }\n",
     "    client.add_label(sample['uuid'], 'ground-truth', attributes, label_status='PRELABELED')"
    ]
@@ -242,7 +245,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -19,7 +19,7 @@
     "# !pip install torchvision\n",
     "# !pip install scikit-image\n",
     "# !pip install setuptools wheel\n",
-    "# !pip install 'git+https://github.com/facebookresearch/detectron2.git\n",
+    "# !pip install 'git+https://github.com/facebookresearch/detectron2.git'\n",
     "# !git clone https://github.com/segments-ai/fast-labeling-workflow\n",
     "# %cd fast-labeling-workflow"
    ]

--- a/tomatoes.json
+++ b/tomatoes.json
@@ -38,7 +38,6 @@
   "https://farm3.staticflickr.com/2923/14260940732_16bb49bd32_c.jpg",
   "https://farm1.staticflickr.com/83/219245358_1ed362b609_c.jpg",
   "https://farm8.staticflickr.com/7138/8164463933_a60a81fbd4_c.jpg",
-  "https://farm6.staticflickr.com/5752/31116586465_ec723cb2bb_c.jpg",
   "https://farm8.staticflickr.com/7277/8164499878_a163a204ac_c.jpg",
   "https://farm4.staticflickr.com/3744/14262690634_30d39c3037_c.jpg",
   "https://farm2.staticflickr.com/1080/1061718736_d400ce0742_c.jpg",


### PR DESCRIPTION
**Changes in notebook**:
 - Now creating the dataset using the SDK. Now the user only needs to change their API key
 - Minor fix for newer SDK version
 - Adjusted installation commands for colab
   - [x] Test in clean colab instance
   - I relaxed the version requirements, this has gotten me better experiences with detectron2 in the past 
   - Detectron2 is also built from source now. `pip` does this for you, so in colab it does this transparently. This should make it much more resilient w.r.t. python and package version changes
     - **Downside**: this is significantly slower, running the installation took ~4 minutes in colab


**Other changes**:
 - Adjusted the gitignore to include the training and data folders
 - Removed an image from "tomatoes.json", it wasn't available anymore which was causing problems when fetching the data from segments.ai